### PR TITLE
add etoolbox as required package

### DIFF
--- a/synthslant.dtx
+++ b/synthslant.dtx
@@ -2115,6 +2115,7 @@ end
 \ProvidesPackage{synthslant}
                 [2024/05/08  v0.1a  Synthetically Slant glyphs]
 
+\RequirePackage{etoolbox}
 \RequirePackage{iftex}
 \RequirePackage{xkeyval}
 


### PR DESCRIPTION
The use of `\newrobustcmd` means etoolbox should be a required package. For example, the following document errors:
```tex
\documentclass{article}
% \usepackage{etoolbox} % errors if commented
\usepackage{synthslant}

\begin{document}

\textsynthslant{abc}

\end{document}
```